### PR TITLE
Fix a bug that prevent vim-ipython to load  from vim in console mode

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -371,8 +371,10 @@ vim.command("let l:doc = %s"% reply)
 endpython
 return l:doc
 endfunction
-set bexpr=IPythonBalloonExpr()
-set ballooneval
+if has("gui_running")
+	set bexpr=IPythonBalloonExpr()
+	set ballooneval
+endif
 
 fun! CompleteIPython(findstart, base)
 	  if a:findstart


### PR DESCRIPTION
If I am not wrong, (Console) Vim does not offer the balloons support. Hence, the plugin fails to load
in console mode (at the "set bexpr" instruction).

This small workaround loads the balloons only when Gvim is started.
