### PR TITLE
The function set_this_line does not exist. Avoid errors when typing C-P

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -432,7 +432,6 @@ if g:ipy_perform_mappings != 0
     map <silent> <M-s> :python dedent_run_this_line()<CR>
     vmap <silent> <C-S> :python run_these_lines()<CR>
     vmap <silent> <M-s> :python dedent_run_these_lines()<CR>
-    map <silent> <C-p> :python set_this_line()<CR>
     map <silent> <M-c> I#<ESC>
     vmap <silent> <M-c> I#<ESC>
     map <silent> <M-C> :s/^\([ \t]*\)#/\1/<CR>


### PR DESCRIPTION
It's annoying to have the error:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
NameError: name 'set_this_line' is not defined  
