### PR TITLE
Exit gracefully in case python is not available.

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -16,6 +16,10 @@
 "   (or :IPythonXSelection if you're using X11 without having to copy)
 "
 " written by Paul Ivanov (http://pirsquared.org)
+if !has('python')
+    " exit if python is not available.
+    finish
+endif
 python << EOF
 reselect = False            # reselect lines after sending from Visual mode
 show_execution_count = True # wait to get numbers for In[43]: feedback?


### PR DESCRIPTION
Hey Paul!

This small patch lets the script exit quietly when python support is not
available rather then throwing multiple errors. This makes it easier to
share the vim configuration between different vim installations (eg.
macvim and the builtin /usr/bin/vim without python support on Mac OSX).
