### PR TITLE
execute visual/motion; syntax of doc window

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -188,6 +188,10 @@ def get_doc_buffer(level=0):
     #vim.command('pcl')
     #vim.command('pedit doc')
     #vim.command('normal ') # go to previous window
+    # "rest" is the syntax of python documentation.  Stock vim doesn't have
+    # a syntax file for rest, but if the user has installed one then this will
+    # cause the docs to be colorized.
+    vim.command('setlocal syntax=rest')
 
 def update_subchannel_msgs(debug=False):
     msgs = km.sub_channel.get_msgs()


### PR DESCRIPTION
Paul,

I have made three changes:

1) The doc window gets "set syntax=rest" so that it can be colorized properly if the user has installed the rest syntax plugin (which isn't part of stock vim).

2) Ability to execute a block of python code selected visually, or via a motion command.  I have mapped "&lt;leader>p" for this purpose, although feel free to change that of course.  "&lt;leader>p" with code visually selected of course executes that visual selection.  In normal mode, "&lt;leader>p" acts as an operator which takes a motion.  So for instance "\piw" executes the current word, "\pi)" executes stuff within parenthesis, "\pp" executes the current line, etc.  This is useful for inspecting the value of a variable or half of an expression.

3) I have made some of the key mappings route through "&lt;Plug>" mappings.  So for instance, there is a mapping "&lt;Plug>IPyRunLine" for running the current line.  The advantage of doing it this way is that users are able to easily set up the key mappings however they want.  See ":help using-&lt;Plug>" for more info on this.
- Dan
