### PR TITLE
Activate completion *after* ipython connection

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -107,6 +107,9 @@ def km_from_string(s=''):
             return
     km.start_channels()
     send = km.shell_channel.execute
+
+    # now that we're connect to an ipython kernel, activate completion machinery
+    vim.command('set completefunc=CompleteIPython')
     return km
 
 def echo(arg,style="Question"):
@@ -522,4 +525,3 @@ endpython
 	    return res
 	  endif
 	endfun
-set completefunc=CompleteIPython


### PR DESCRIPTION
CompleteIPython throws errors if it is not connected to an ipython kernel and you try to tab complete something.  This delays setting completefunc=CompleteIPython until the end of km_from_string.
