### PR TITLE
Option to make completion for active buffer only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,10 @@ In your own ``.vimrc``, if you don't like the mappings provided by default,
 you can define a variable ``let g:ipy_perform_mappings=0`` which will prevent
 vim-ipython from defining any of the default mappings.
 
+**Making autocompletion local to a buffer**
+Sometimes autocompletion from ipy breaks other plugins' completions - by setting a variable
+``let g:ipy_local_copletefunc`` vim will use ipy completion only for current buffer.
+
 ---------------
 Current issues:
 ---------------

--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -22,6 +22,9 @@ if !has('python')
     " exit if python is not available.
     finish
 endif
+if !exists('g:ipy_local_copletefunc')
+    let g:ipy_local_copletefunc = 0
+endif
 python << EOF
 reselect = False            # reselect lines after sending from Visual mode
 show_execution_count = True # wait to get numbers for In[43]: feedback?
@@ -116,7 +119,10 @@ def km_from_string(s=''):
     send = km.shell_channel.execute
 
     # now that we're connect to an ipython kernel, activate completion machinery
-    vim.command('set completefunc=CompleteIPython')
+    if vim.command('g:ipy_local_copletefunc'):
+        vim.command('setl completefunc=CompleteIPython')
+    else:
+        vim.command('set completefunc=CompleteIPython')
     # also activate GUI doc balloons if in gvim
     vim.command("""
         if has('balloon_eval')


### PR DESCRIPTION
Without this option vim-ipython breaks neocomplcache and possibly other plug-ins that perform some major completion tinkering ;)
