### PR TITLE
Added Matlab-like cell behavior

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ You can also send whole files to IPython's ``%run`` magic using ``<F5>``.
 
 To execute predefined sections of a script, you can define Matlab-like cells
 using either ``##`` or ``# <codecell>`` markers. To execute a cell, move the
-cursor somewhere within it and press ``<Ctrl-Alt-S>``::
+cursor somewhere within it and press ``<Ctrl-Enter>``::
 
   ## Do something
   print('Hello')

--- a/README.rst
+++ b/README.rst
@@ -170,12 +170,12 @@ not work on Windows, please report the issue to ).
 -------
 Options
 -------
-You can change these at the top of the ipy.vim::
+You can change these in your vimrc::
 
-  reselect = False            # reselect lines after sending from Visual mode
-  show_execution_count = True # wait to get numbers for In[43]: feedback?
-  monitor_subchannel = True   # update vim-ipython 'shell' on every send?
-  run_flags= "-i"             # flags to for IPython's run magic when using <F5>
+  g:ipy_reselect = 0             # reselect lines after sending from Visual mode
+  g:ipy_show_execution_count = 1 # wait to get numbers for In[43]: feedback?
+  g:ipy_monitor_subchannel = 1   # update vim-ipython 'shell' on every send?
+  g:ipy_run_flags = '-i'         # flags to for IPython's run magic when using <F5>
 
 **Disabling default mappings**
 In your own ``.vimrc``, if you don't like the mappings provided by default,
@@ -312,6 +312,7 @@ pull request with your attribution.
 * @luispedro for IPythonNew
 * @jjhelmus for IPython 3.x support.
 * @wmvanvliet for Matlab-like cell support.
+* @wmvanvliet for config support through vim-globals.
 
 Similar Projects
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,23 @@ Then, go to the qtconsole and run this line::
 
 You can also send whole files to IPython's ``%run`` magic using ``<F5>``.
 
+To execute predefined sections of a script, you can define Matlab-like cells
+using either ``##`` or ``# <codecell>`` markers. To execute a cell, move the
+cursor somewhere within it and press ``<Ctrl-Alt-S>``::
+
+  ## Do something
+  print('Hello')
+  
+  ## Do something else
+  print('IPython')
+
+  # <codecell> This is an alternative cell marker
+  print('World!')
+ 
+Cells (when deliminated by '# <codecell>' markers) are two-way compatible with
+IPython notebooks, so you can easily switch between browser and Vim without
+loosing them.
+
 **NEW in IPython 0.12**!
 If you're trying to do run code fragments that have leading whitespace, use
 ``<Alt-S>`` instead - it will dedent a single line, and remove the leading
@@ -294,6 +311,7 @@ pull request with your attribution.
 * @pydave for IPythonTerminate (sending SIGTERM using our hack)
 * @luispedro for IPythonNew
 * @jjhelmus for IPython 3.x support.
+* @wmvanvliet for Matlab-like cell support.
 
 Similar Projects
 ----------------

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ This is a list of things I'm planning to work on with vim-ipython
 
 [ ] support for non-python kernels (IJulia, IHaskell kernel)
 
-[ ] provide g:ipy variables to set the initial state of python vars 
+[x] provide g:ipy variables to set the initial state of python vars 
     e.g. monitor_subchannel
 
 [ ] put debugging support back in

--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -63,7 +63,7 @@ endif
 
 " flags to for IPython's run magic when using <F5>
 if !exists('g:ipy_run_flags')
-	let g:ipy_un_flags = '-i'
+	let g:ipy_run_flags = '-i'
 endif
 
 python << EOF

--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -46,6 +46,26 @@ if !exists('g:ipy_completefunc')
     let g:ipy_completefunc = 'global'
 endif
 
+" reselect lines after sending from Visual mode
+if !exists('g:ipy_reselect')
+	let g:ipy_select = 0
+endif
+
+" wait to get numbers for In[43]: feedback?
+if !exists('g:ipy_show_execution_count')
+	let g:ipy_show_execution_count = 1
+endif
+
+" update vim-ipython 'shell' on every send?
+if !exists('g:ipy_monitor_subchannel')
+	let g:ipy_monitor_subchannel = 1
+endif
+
+" flags to for IPython's run magic when using <F5>
+if !exists('g:ipy_run_flags')
+	let g:ipy_un_flags = '-i'
+endif
+
 python << EOF
 import vim
 import sys

--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -29,6 +29,11 @@ if !exists('g:ipy_perform_mappings')
     let g:ipy_perform_mappings = 1
 endif
 
+" Enable cell folding
+if !exists('g:ipy_cell_folding')
+    let g:ipy_cell_folding = 0
+endif
+
 " Register IPython completefunc
 " 'global'   -- for all of vim (default).
 " 'local'    -- only for the current buffer.
@@ -109,6 +114,7 @@ noremap  <Plug>(IPython-PlotClearCurrent)   :python run_command("plt.clf()")<CR>
 noremap  <Plug>(IPython-PlotCloseAll)       :python run_command("plt.close('all')")<CR>
 noremap  <Plug>(IPython-RunLineAsTopLevel)  :python dedent_run_this_line()<CR>
 xnoremap <Plug>(IPython-RunLinesAsTopLevel) :python dedent_run_these_lines()<CR>
+noremap  <Plug>(IPython-EnableFoldByCell)   :call EnableFoldByCell()<CR>
 
 if g:ipy_perform_mappings != 0
     map  <buffer> <silent> <F5>           <Plug>(IPython-RunFile)
@@ -209,3 +215,24 @@ endpython
         return res
       endif
     endfun
+
+" Custom folding function to fold cells
+function! FoldByCell(lnum)
+    let pattern = '\v^\s*(##|' . escape('# <codecell>', '<>') . ').*$'
+    if getline(a:lnum) =~? pattern
+        return '>1'
+    elseif getline(a:lnum+1) =~? pattern
+        return '<1'
+    else
+        return '='
+    endif
+endfunction
+
+function! EnableFoldByCell()
+	setlocal foldmethod=expr
+	setlocal foldexpr=FoldByCell(v:lnum)
+endfunction
+
+if g:ipy_cell_folding != 0
+    call EnableFoldByCell()
+endif

--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -95,6 +95,7 @@ au BufEnter vim-ipython :python if update_subchannel_msgs(): echo("vim-ipython s
 noremap  <Plug>(IPython-RunFile)            :python run_this_file()<CR>
 noremap  <Plug>(IPython-RunLine)            :python run_this_line()<CR>
 noremap  <Plug>(IPython-RunLines)           :python run_these_lines()<CR>
+noremap  <Plug>(IPython-RunCell)            :python run_this_cell()<CR>
 noremap  <Plug>(IPython-OpenPyDoc)          :python get_doc_buffer()<CR>
 noremap  <Plug>(IPython-UpdateShell)        :python if update_subchannel_msgs(force=True): echo("vim-ipython shell updated",'Operator')<CR>
 noremap  <Plug>(IPython-ToggleReselect)     :python toggle_reselect()<CR>
@@ -113,6 +114,7 @@ if g:ipy_perform_mappings != 0
     map  <buffer> <silent> <F5>           <Plug>(IPython-RunFile)
     map  <buffer> <silent> <S-F5>         <Plug>(IPython-RunLine)
     map  <buffer> <silent> <F9>           <Plug>(IPython-RunLines)
+    map  <buffer> <silent> <C-M-F5>       <Plug>(IPython-RunCell)
     map  <buffer> <silent> <LocalLeader>d <Plug>(IPython-OpenPyDoc)
     map  <buffer> <silent> <LocalLeader>s <Plug>(IPython-UpdateShell)
     map  <buffer> <silent> <S-F9>         <Plug>(IPython-ToggleReselect)
@@ -124,6 +126,7 @@ if g:ipy_perform_mappings != 0
     imap <buffer>          <C-F5>         <C-o><Plug>(IPython-RunFile)
     imap <buffer>          <S-F5>         <C-o><Plug>(IPython-RunLines)
     imap <buffer> <silent> <F5>           <C-o><Plug>(IPython-RunFile)
+    imap <buffer> <silent> <C-M-F5>       <C-o><Plug>(IPython-RunCell)
     map  <buffer>          <C-F5>         <Plug>(IPython-ToggleSendOnSave)
     "" Example of how to quickly clear the current plot with a keystroke
     "map  <buffer> <silent> <F12>          <Plug>(IPython-PlotClearCurrent)
@@ -137,6 +140,7 @@ if g:ipy_perform_mappings != 0
     map  <buffer> <silent> <M-s>          <Plug>(IPython-RunLineAsTopLevel)
     xmap <buffer> <silent> <C-S>          <Plug>(IPython-RunLines)
     xmap <buffer> <silent> <M-s>          <Plug>(IPython-RunLinesAsTopLevel)
+    map  <buffer> <silent> <C-Return>     <Plug>(IPython-RunCell)
 
     noremap  <buffer> <silent> <M-c>      I#<ESC>
     xnoremap <buffer> <silent> <M-c>      I#<ESC>

--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -48,7 +48,7 @@ endif
 
 " reselect lines after sending from Visual mode
 if !exists('g:ipy_reselect')
-	let g:ipy_select = 0
+	let g:ipy_reselect = 0
 endif
 
 " wait to get numbers for In[43]: feedback?

--- a/ftplugin/python/vim_ipython.py
+++ b/ftplugin/python/vim_ipython.py
@@ -15,11 +15,13 @@ except ImportError:
 import sys
 
 # Read global configuration variables
-reselect = vim.eval("g:ipy_reselect") 
-show_execution_count = vim.eval("g:ipy_show_execution_count")
-monitor_subchannel = vim.eval("g:ipy_monitor_subchannel")
+reselect = bool(vim.eval("g:ipy_reselect"))
+show_execution_count = bool(vim.eval("g:ipy_show_execution_count"))
+monitor_subchannel = bool(vim.eval("g:ipy_monitor_subchannel"))
 run_flags = vim.eval("g:ipy_run_flags")
 current_line = ""
+
+print('Subchannel:', monitor_subchannel)
 
 # get around unicode problems when interfacing with vim
 vim_encoding=vim.eval('&encoding') or 'utf-8'

--- a/ftplugin/python/vim_ipython.py
+++ b/ftplugin/python/vim_ipython.py
@@ -1,9 +1,3 @@
-reselect = False            # reselect lines after sending from Visual mode
-show_execution_count = True # wait to get numbers for In[43]: feedback?
-monitor_subchannel = True   # update vim-ipython 'shell' on every send?
-run_flags= "-i"             # flags to for IPython's run magic when using <F5>
-current_line = ''
-
 try:
     from queue import Empty # python3 convention
 except ImportError:
@@ -19,6 +13,13 @@ except ImportError:
     print("uh oh, not running inside vim")
 
 import sys
+
+# Read global configuration variables
+reselect = vim.eval("g:ipy_reselect") 
+show_execution_count = vim.eval("g:ipy_show_execution_count")
+monitor_subchannel = vim.eval("g:ipy_monitor_subchannel")
+run_flags = vim.eval("g:ipy_run_flags")
+current_line = ""
 
 # get around unicode problems when interfacing with vim
 vim_encoding=vim.eval('&encoding') or 'utf-8'

--- a/ftplugin/python/vim_ipython.py
+++ b/ftplugin/python/vim_ipython.py
@@ -21,8 +21,6 @@ monitor_subchannel = bool(int(vim.eval("g:ipy_monitor_subchannel")))
 run_flags = vim.eval("g:ipy_run_flags")
 current_line = ""
 
-print('Subchannel:', monitor_subchannel)
-
 # get around unicode problems when interfacing with vim
 vim_encoding=vim.eval('&encoding') or 'utf-8'
 

--- a/ftplugin/python/vim_ipython.py
+++ b/ftplugin/python/vim_ipython.py
@@ -15,9 +15,9 @@ except ImportError:
 import sys
 
 # Read global configuration variables
-reselect = bool(vim.eval("g:ipy_reselect"))
-show_execution_count = bool(vim.eval("g:ipy_show_execution_count"))
-monitor_subchannel = bool(vim.eval("g:ipy_monitor_subchannel"))
+reselect = bool(int(vim.eval("g:ipy_reselect")))
+show_execution_count = bool(int(vim.eval("g:ipy_show_execution_count")))
+monitor_subchannel = bool(int(vim.eval("g:ipy_monitor_subchannel")))
 run_flags = vim.eval("g:ipy_run_flags")
 current_line = ""
 

--- a/ftplugin/python/vim_ipython.py
+++ b/ftplugin/python/vim_ipython.py
@@ -640,6 +640,71 @@ def dedent_run_this_line():
 def dedent_run_these_lines():
     run_these_lines(True)
 
+def is_cell_separator(line):
+    '''Determines whether a given line is a cell separator'''
+    cell_sep = ['##', '# <codecell>']
+    for sep in cell_sep:
+        if line.strip().startswith(sep):
+            return True
+    return False
+
+@with_subchannel
+def run_this_cell():
+    '''Runs all the code in between two cell separators'''
+    b = vim.current.buffer
+    (cur_line, cur_col) = vim.current.window.cursor
+    cur_line -= 1
+
+    # Search upwards for cell separator
+    upper_bound = cur_line
+    while upper_bound > 0 and not is_cell_separator(vim.current.buffer[upper_bound]):
+        upper_bound -= 1
+
+    # Skip past the first cell separator if it exists
+    if is_cell_separator(vim.current.buffer[upper_bound]):
+        upper_bound += 1
+
+    # Search downwards for cell separator
+    lower_bound = min(upper_bound+1, len(vim.current.buffer)-1)
+
+    while lower_bound < len(vim.current.buffer)-1 and not is_cell_separator(vim.current.buffer[lower_bound]):
+        lower_bound += 1
+
+    # Move before the last cell separator if it exists
+    if is_cell_separator(vim.current.buffer[lower_bound]):
+        lower_bound -= 1
+
+    # Make sure bounds are within buffer limits
+    upper_bound = max(0, min(upper_bound, len(vim.current.buffer)-1))
+    lower_bound = max(0, min(lower_bound, len(vim.current.buffer)-1))
+
+    # Make sure of proper ordering of bounds
+    lower_bound = max(upper_bound, lower_bound)
+
+    # Calculate minimum indentation level of entire cell
+    shiftwidth = vim.eval('&shiftwidth')
+    count = lambda x: int(vim.eval('indent(%d)/%s' % (x,shiftwidth)))
+
+    min_indent = count(upper_bound+1)
+    for i in range(upper_bound+1, lower_bound):
+        indent = count(i)
+        if i < min_indent:
+            min_indent = i
+
+    # Perform dedent
+    if min_indent > 0:
+        vim.command('%d,%d%s' % (upper_bound+1, lower_bound+1, '<'*min_indent))
+
+    # Execute cell
+    lines = "\n".join(vim.current.buffer[upper_bound:lower_bound+1])
+    msg_id = send(lines)
+    prompt = "lines %d-%d "% (upper_bound+1,lower_bound+1)
+    print_prompt(prompt, msg_id)
+
+    # Re-indent
+    if min_indent > 0:
+        vim.command("silent undo")
+
 #def set_this_line():
 #    # not sure if there's a way to do this, since we have multiple clients
 #    send("get_ipython().shell.set_next_input(\'%s\')" % vim.current.line.replace("\'","\\\'"))


### PR DESCRIPTION
I've added a cell mode like Matlab has, where %% marks delimit cells, which can be executed one by one. In Python, the marker is `# <codecell>` to be compatible with IPython notebook cells. You can now do stuff like:

    # <codecell> Preprocessing
    
    filter()
    another-filter()
    
    # <codecell> Plot it!
    
    plot(data)
    ...

And execute cells one by one by moving the cursor inside and pressing ``Ctrl-Alt-S``