### PR TITLE
Only dedent and undo if there is an indent

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -483,9 +483,11 @@ def dedent_run_these_lines():
     r = vim.current.range
     shiftwidth = vim.eval('&shiftwidth')
     count = int(vim.eval('indent(%d+1)/%s' % (r.start,shiftwidth)))
-    vim.command("'<,'>" + "<"*count)
+    if count > 0:
+       vim.command("'<,'>" + "<"*count)
     run_these_lines()
-    vim.command("silent undo")
+    if count > 0:
+       vim.command("silent undo")
     
 #def set_this_line():
 #    # not sure if there's a way to do this, since we have multiple clients


### PR DESCRIPTION
I prefer to use the same keystrokes to run a snippet regardless of whether it is indented.  This change should allow me to always use the dedent_run_lines().

thanks very a very useful project.
