### PR TITLE
Clean up mappings: LocalLeader, Plug, and noremap

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -572,11 +572,11 @@ noremap  <Plug>(IPython-RunLines)           :python run_these_lines()<CR>
 noremap  <Plug>(IPython-OpenPyDoc)          :python get_doc_buffer()<CR>
 noremap  <Plug>(IPython-UpdateShell)        :python if update_subchannel_msgs(force=True): echo("vim-ipython shell updated",'Operator')<CR>
 noremap  <Plug>(IPython-ToggleReselect)     :python toggle_reselect()<CR>
-noremap  <Plug>(IPython-StartDebugging)     :python send('%pdb')<CR>
-noremap  <Plug>(IPython-BreakpointSet)      :python set_breakpoint()<CR>
-noremap  <Plug>(IPython-BreakpointClear)    :python clear_breakpoint()<CR>
-noremap  <Plug>(IPython-DebugThisFile)      :python run_this_file_pdb()<CR>
-noremap  <Plug>(IPython-BreakpointClearAll) :python clear_all_breaks()<CR>
+"noremap  <Plug>(IPython-StartDebugging)     :python send('%pdb')<CR>
+"noremap  <Plug>(IPython-BreakpointSet)      :python set_breakpoint()<CR>
+"noremap  <Plug>(IPython-BreakpointClear)    :python clear_breakpoint()<CR>
+"noremap  <Plug>(IPython-DebugThisFile)      :python run_this_file_pdb()<CR>
+"noremap  <Plug>(IPython-BreakpointClearAll) :python clear_all_breaks()<CR>
 noremap  <Plug>(IPython-ToggleSendOnSave)   :call <SID>toggle_send_on_save()<CR>
 noremap  <Plug>(IPython-PlotClearCurrent)   :python run_command("plt.clf()")<CR>
 noremap  <Plug>(IPython-PlotCloseAll)       :python run_command("plt.close('all')")<CR>


### PR DESCRIPTION
This is a set of changes to convert vim-ipython to use common vim plugin conventions:
- Use LocalLeader for ftplugins - so users can define filetype-specific and global mapleaders.
- Use `<Plug>` mappings so all mappings can be defined by users (even ones that use `<SID>` functions). This makes it easier to make internal changes (like renaming python functions) without breaking user's mappings.
- Use noremap where possible. Ensures that plugin commands run as expected. As far as I understand, you can't use noremap when mapping to Plug, but maps that start with Plug will never evaluate to a user's sequence of keys, so that shouldn't be a problem.

I tried to break it up into small changes to make the diffs easier to read.
