### PR TITLE
Add IPythonTerminate to close ipython

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -450,13 +450,18 @@ def set_pid():
 
 
 def interrupt_kernel_hack():
+    import signal
+    send_kernel_interrupt(signal.SIGINT)
+def terminate_kernel_hack():
+    import signal
+    send_kernel_interrupt(signal.SIGTERM)
+def send_kernel_interrupt(signal_to_send):
     """
     Sends the interrupt signal to the remote kernel.  This side steps the
     (non-functional) ipython interrupt mechanisms.
     Only works on posix.
     """
     global pid
-    import signal
     import os
     if pid is None:
         # Avoid errors if we couldn't get pid originally,
@@ -467,9 +472,9 @@ def interrupt_kernel_hack():
             echo("cannot get kernel PID, Ctrl-C will not be supported")
             return
     echo("KeyboardInterrupt (sent to ipython: pid " +
-        "%i with signal %i)" % (pid, signal.SIGINT),"Operator")
+        "%i with signal %i)" % (pid, signal_to_send),"Operator")
     try:
-        os.kill(pid, signal.SIGINT)
+        os.kill(pid, signal_to_send)
     except OSError:
         echo("unable to kill pid %d" % pid)
         pid = None
@@ -603,6 +608,7 @@ command! -nargs=* IPython :py km_from_string("<args>")
 command! -nargs=0 IPythonClipboard :py km_from_string(vim.eval('@+'))
 command! -nargs=0 IPythonXSelection :py km_from_string(vim.eval('@*'))
 command! -nargs=0 IPythonInterrupt :py interrupt_kernel_hack()
+command! -nargs=0 IPythonTerminate :py terminate_kernel_hack()
 
 function! IPythonBalloonExpr()
 python << endpython


### PR DESCRIPTION
There's no apparent interface to close ipython aside from sending it a
terminate message, so make a command to send a terminate message.

Extracts most of interrupt_kernel_hack to send_kernel_interrupt which
takes a single argument: the signal.
