### PR TITLE
Making the status buffer friendlier and configurable

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -475,7 +475,7 @@ def run_this_line(dedent=False):
         # question mark and call the get_doc_buffer on it
         w = vim.current.window
         original_pos =  w.cursor
-        new_pos = (original_pos[0], line.index('?')-1)
+        new_pos = (original_pos[0], vim.current.line.index('?')-1)
         w.cursor = new_pos
         if line.rstrip().endswith('??'):
             # double question mark should display source


### PR DESCRIPTION
This firstly fixes some problems of interaction with the status buffer.
- It sets `noswapfile` so that multiple Vim instances can show the status buffer at once without an error about a swap file currently existing appearing – I was really surprised to encounter this problem.
- It sets `nonumber`. Users are unlikely to want to see line numbers there, even if they use them elsewhere.
- It sets `nobuflisted` so that there's no longer an annoying 'vim-ipython' entry in buffer lists like LycosaExplorer.

It also makes the status buffer – particularly the prompts – more configurable.
- At the moment the status prompt is hardcoded to `In[...]` and `Out[...]`, and the colours are fixed. This patch lets the prompt and colours be changed, but leaves the defaults as they currently are. It might be nice if the defaults were instead picked up from the IPython profile, but that increases the complexity.
- This patch shows multiline input more clearly. When running multiple lines, the status currently looks like

```
In[1]: foo = 1
bar = 2
```

this patch changes this so that lines remain lined up correctly:

```
In[1]: foo = 1
...... bar = 2
```
- Finally, this patch makes the newline that is currently added between each input optional.
