### PR TITLE
add option to force preview

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -39,6 +39,11 @@ if !exists('g:ipy_completefunc')
     let g:ipy_completefunc = 'global'
 endif
 
+" Force open preview window
+if !exists('g:ipy_force_preview')
+    let g:ipy_force_preview = 0
+endif
+
 python << EOF
 reselect = False            # reselect lines after sending from Visual mode
 show_execution_count = True # wait to get numbers for In[43]: feedback?
@@ -424,7 +429,7 @@ def with_subchannel(f,*args):
         try:
             f(*args)
             if monitor_subchannel:
-                update_subchannel_msgs()
+              update_subchannel_msgs(False, vim.vars['ipy_force_preview'])
         except AttributeError: #if kc is None
             echo("not connected to IPython", 'Error')
     return f_with_update


### PR DESCRIPTION
the only change is in with_subchannel(). It now passes the value of g:ipy_force_preview on to update_subchannel_msgs(...), so that if g:ipy_force_preview is set to 1, then the preview window will be opened automatically.
