### PR TITLE
invoke IPython's run magic as %run instead of run

### DIFF
--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -431,8 +431,8 @@ def with_subchannel(f,*args):
 
 @with_subchannel
 def run_this_file():
-    msg_id = send('run %s %s' % (run_flags, repr(vim.current.buffer.name),))
-    print_prompt("In[]: run %s %s" % (run_flags, repr(vim.current.buffer.name)),msg_id)
+    msg_id = send('%%run %s %s' % (run_flags, repr(vim.current.buffer.name),))
+    print_prompt("In[]: %%run %s %s" % (run_flags, repr(vim.current.buffer.name)),msg_id)
 
 @with_subchannel
 def run_this_line():


### PR DESCRIPTION
If the source file defines or imports a symbol named 'run', that symbol
takes precedence over IPython's run, leading to a syntax error being
thrown when invoking run_this_file() for the second time

Using %run removes the ambiguity.
