### PR TITLE
Fixed broken paths for IPython > 1.x

### DIFF
--- a/ftplugin/python/vim_ipython.py
+++ b/ftplugin/python/vim_ipython.py
@@ -109,10 +109,8 @@ def km_from_string(s=''):
         raise ImportError("Could not find IPython. " + _install_instructions)
     from IPython.config.loader import KeyValueConfigLoader
     try:
-        from IPython.kernel import (
-            KernelManager,
-            find_connection_file,
-        )
+        from IPython.kernel.manager import KernelManager
+        from IPython.kernel.connect import find_connection_file
     except ImportError:
         #  IPython < 1.0
         from IPython.zmq.blockingkernelmanager import BlockingKernelManager as KernelManager


### PR DESCRIPTION
In `ipython` > 1.x, the correct paths for `KernelManager` and `find_connection_file` are `IPython.kernel.manager.KernelManager` and `IPython.kernel.connect.find_connection_file` respectively.  See:

http://ipython.org/ipython-doc/2/api/generated/IPython.kernel.manager.html#module-IPython.kernel.manager
http://ipython.org/ipython-doc/2/api/generated/IPython.kernel.connect.html#module-IPython.kernel.connect

Let me know if this breaks for other versions of IPython, and I can write code to accommodate those.

Thanks so much for building this awesome plugin!
