### PR TITLE
Add support for MATLAB-like cells

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ You can also send whole files to IPython's ``%run`` magic using ``<F5>``.
 
 To execute predefined sections of a script, you can define Matlab-like cells
 using either ``##`` or ``# <codecell>`` markers. To execute a cell, move the
-cursor somewhere within it and press ``<Ctrl-Alt-S>``::
+cursor somewhere within it and press ``<Ctrl-Enter>``::
 
   ## Do something
   print('Hello')

--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,23 @@ Then, go to the qtconsole and run this line::
 
 You can also send whole files to IPython's ``%run`` magic using ``<F5>``.
 
+To execute predefined sections of a script, you can define Matlab-like cells
+using either ``##`` or ``# <codecell>`` markers. To execute a cell, move the
+cursor somewhere within it and press ``<Ctrl-Alt-S>``::
+
+  ## Do something
+  print('Hello')
+  
+  ## Do something else
+  print('IPython')
+
+  # <codecell> This is an alternative cell marker
+  print('World!')
+ 
+Cells (when deliminated by '# <codecell>' markers) are two-way compatible with
+IPython notebooks, so you can easily switch between browser and Vim without
+loosing them.
+
 **NEW in IPython 0.12**!
 If you're trying to do run code fragments that have leading whitespace, use
 ``<Alt-S>`` instead - it will dedent a single line, and remove the leading
@@ -294,6 +311,7 @@ pull request with your attribution.
 * @pydave for IPythonTerminate (sending SIGTERM using our hack)
 * @luispedro for IPythonNew
 * @jjhelmus for IPython 3.x support.
+* @wmvanvliet for Matlab-like cell support.
 
 Similar Projects
 ----------------

--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -95,6 +95,7 @@ au BufEnter vim-ipython :python if update_subchannel_msgs(): echo("vim-ipython s
 noremap  <Plug>(IPython-RunFile)            :python run_this_file()<CR>
 noremap  <Plug>(IPython-RunLine)            :python run_this_line()<CR>
 noremap  <Plug>(IPython-RunLines)           :python run_these_lines()<CR>
+noremap  <Plug>(IPython-RunCell)            :python run_this_cell()<CR>
 noremap  <Plug>(IPython-OpenPyDoc)          :python get_doc_buffer()<CR>
 noremap  <Plug>(IPython-UpdateShell)        :python if update_subchannel_msgs(force=True): echo("vim-ipython shell updated",'Operator')<CR>
 noremap  <Plug>(IPython-ToggleReselect)     :python toggle_reselect()<CR>
@@ -113,6 +114,7 @@ if g:ipy_perform_mappings != 0
     map  <buffer> <silent> <F5>           <Plug>(IPython-RunFile)
     map  <buffer> <silent> <S-F5>         <Plug>(IPython-RunLine)
     map  <buffer> <silent> <F9>           <Plug>(IPython-RunLines)
+    map  <buffer> <silent> <C-M-F5>       <Plug>(IPython-RunCell)
     map  <buffer> <silent> <LocalLeader>d <Plug>(IPython-OpenPyDoc)
     map  <buffer> <silent> <LocalLeader>s <Plug>(IPython-UpdateShell)
     map  <buffer> <silent> <S-F9>         <Plug>(IPython-ToggleReselect)
@@ -124,6 +126,7 @@ if g:ipy_perform_mappings != 0
     imap <buffer>          <C-F5>         <C-o><Plug>(IPython-RunFile)
     imap <buffer>          <S-F5>         <C-o><Plug>(IPython-RunLines)
     imap <buffer> <silent> <F5>           <C-o><Plug>(IPython-RunFile)
+    imap <buffer> <silent> <C-M-F5>       <C-o><Plug>(IPython-RunCell)
     map  <buffer>          <C-F5>         <Plug>(IPython-ToggleSendOnSave)
     "" Example of how to quickly clear the current plot with a keystroke
     "map  <buffer> <silent> <F12>          <Plug>(IPython-PlotClearCurrent)
@@ -137,6 +140,7 @@ if g:ipy_perform_mappings != 0
     map  <buffer> <silent> <M-s>          <Plug>(IPython-RunLineAsTopLevel)
     xmap <buffer> <silent> <C-S>          <Plug>(IPython-RunLines)
     xmap <buffer> <silent> <M-s>          <Plug>(IPython-RunLinesAsTopLevel)
+    map  <buffer> <silent> <C-Return>     <Plug>(IPython-RunCell)
 
     noremap  <buffer> <silent> <M-c>      I#<ESC>
     xnoremap <buffer> <silent> <M-c>      I#<ESC>


### PR DESCRIPTION
When working on a longish script, its common to have chunks that need to
be executed frequently. For example, a computation you are working on that
spans multiple lines, or a plot that you are trying to get just right.
When using an IPython notebook, you would put these chunks in cells.
MATLAB has a similar idea, where %% markers deliminate cells, which can
be executed with a single key press.

With this PR, you can define cells like this:

    print('Performing computation')
    a = 1 + 2
    b = a ** a

    ## Begin new cell

    print('Result of computation:')
    print(b)

Now you can execute the two cells independently.