### PR TITLE
Control config through vim globals

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,12 +153,12 @@ not work on Windows, please report the issue to ).
 -------
 Options
 -------
-You can change these at the top of the ipy.vim::
+You can change these in your vimrc::
 
-  reselect = False            # reselect lines after sending from Visual mode
-  show_execution_count = True # wait to get numbers for In[43]: feedback?
-  monitor_subchannel = True   # update vim-ipython 'shell' on every send?
-  run_flags= "-i"             # flags to for IPython's run magic when using <F5>
+  g:ipy_reselect = 0             # reselect lines after sending from Visual mode
+  g:ipy_show_execution_count = 1 # wait to get numbers for In[43]: feedback?
+  g:ipy_monitor_subchannel = 1   # update vim-ipython 'shell' on every send?
+  g:ipy_run_flags = '-i'         # flags to for IPython's run magic when using <F5>
 
 **Disabling default mappings**
 In your own ``.vimrc``, if you don't like the mappings provided by default,
@@ -294,6 +294,7 @@ pull request with your attribution.
 * @pydave for IPythonTerminate (sending SIGTERM using our hack)
 * @luispedro for IPythonNew
 * @jjhelmus for IPython 3.x support.
+* @wmvanvliet for config support through vim-globals.
 
 Similar Projects
 ----------------

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ This is a list of things I'm planning to work on with vim-ipython
 
 [ ] support for non-python kernels (IJulia, IHaskell kernel)
 
-[ ] provide g:ipy variables to set the initial state of python vars 
+[x] provide g:ipy variables to set the initial state of python vars 
     e.g. monitor_subchannel
 
 [ ] put debugging support back in

--- a/ftplugin/python/ipy.vim
+++ b/ftplugin/python/ipy.vim
@@ -41,6 +41,26 @@ if !exists('g:ipy_completefunc')
     let g:ipy_completefunc = 'global'
 endif
 
+" reselect lines after sending from Visual mode
+if !exists('g:ipy_reselect')
+	let g:ipy_reselect = 0
+endif
+
+" wait to get numbers for In[43]: feedback?
+if !exists('g:ipy_show_execution_count')
+	let g:ipy_show_execution_count = 1
+endif
+
+" update vim-ipython 'shell' on every send?
+if !exists('g:ipy_monitor_subchannel')
+	let g:ipy_monitor_subchannel = 1
+endif
+
+" flags to for IPython's run magic when using <F5>
+if !exists('g:ipy_run_flags')
+	let g:ipy_run_flags = '-i'
+endif
+
 python << EOF
 import vim
 import sys

--- a/ftplugin/python/vim_ipython.py
+++ b/ftplugin/python/vim_ipython.py
@@ -1,9 +1,3 @@
-reselect = False            # reselect lines after sending from Visual mode
-show_execution_count = True # wait to get numbers for In[43]: feedback?
-monitor_subchannel = True   # update vim-ipython 'shell' on every send?
-run_flags= "-i"             # flags to for IPython's run magic when using <F5>
-current_line = ''
-
 try:
     from queue import Empty # python3 convention
 except ImportError:
@@ -19,6 +13,13 @@ except ImportError:
     print("uh oh, not running inside vim")
 
 import sys
+
+# Read global configuration variables
+reselect = bool(int(vim.eval("g:ipy_reselect")))
+show_execution_count = bool(int(vim.eval("g:ipy_show_execution_count")))
+monitor_subchannel = bool(int(vim.eval("g:ipy_monitor_subchannel")))
+run_flags = vim.eval("g:ipy_run_flags")
+current_line = ""
 
 # get around unicode problems when interfacing with vim
 vim_encoding=vim.eval('&encoding') or 'utf-8'


### PR DESCRIPTION
This PR allows the user to configure some aspects of vim-ipython through
the usage of `g:ipy_*` globals.
