### PR TITLE
Support for IPython/Jupyter 4.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,9 @@
 vim-ipython
 ###########
 
-A two-way integration between Vim and IPython.
+A two-way integration between Vim and IPython/Jupyter.
 
-IPython versions 0.11.x, 0.12.x, 0.13.x, 1.x, 2.x and 3.x
+IPython/Jupyter versions 0.11.x, 0.12.x, 0.13.x, 1.x, 2.x, 3.x, 4.x
 
 * author: Paul Ivanov (http://pirsquared.org)
 * github: http://github.com/ivanov/vim-ipython
@@ -294,6 +294,7 @@ pull request with your attribution.
 * @pydave for IPythonTerminate (sending SIGTERM using our hack)
 * @luispedro for IPythonNew
 * @jjhelmus and @wmvanvliet for IPython 3.x support.
+* @jjhelmus and @deto for IPython/Jupyter 4.x support.
 
 Similar Projects
 ----------------

--- a/ftplugin/python/vim_ipython.py
+++ b/ftplugin/python/vim_ipython.py
@@ -335,8 +335,11 @@ def get_doc_buffer(level=0):
 def ipy_complete(base, current_line, pos):
     # pos is the location of the start of base, add the length
     # to get the completion position
-    msg_id = kc.shell_channel.complete(base, current_line,
-                                       int(pos) + len(base) - 1)
+    if hasattr(kc, 'complete'):
+        msg_id = kc.complete(current_line, int(pos) + len(base) - 1)
+    else:
+        msg_id = kc.shell_channel.complete(base, current_line,
+                                           int(pos) + len(base) - 1)
     try:
         m = get_child_msg(msg_id)
         matches = m['content']['matches']

--- a/ftplugin/python/vim_ipython.py
+++ b/ftplugin/python/vim_ipython.py
@@ -244,7 +244,10 @@ def disconnect():
 def get_doc(word, level=0):
     if kc is None:
         return ["Not connected to IPython, cannot query: %s" % word]
-    msg_id = kc.shell_channel.object_info(word, level)
+    if hasattr(kc, 'inspect'):  # IPython/Jupyter 4.x
+        msg_id = kc.inspect(word, None, level)
+    else:  # IPython <= 3
+        msg_id = kc.shell_channel.object_info(word, level)
     doc = get_doc_msg(msg_id)
     # get around unicode problems when interfacing with vim
     return [d.encode(vim_encoding) for d in doc]


### PR DESCRIPTION
Support for IPython/Jupyter 4.x using the jupyter_client modules.  

Method of connecting to 4.x kernels is based off @deto work in PR#144.
