### PR TITLE
Utilize Jupyter for instantiating a kernel connection in IPython >= 4

### DIFF
--- a/plugin/ipy.vim
+++ b/plugin/ipy.vim
@@ -6,7 +6,7 @@ import traceback
 path, line = traceback.extract_tb(sys.last_traceback)[-1][0:2]
 'edit +%d %s' % (line, path)
 """
-reply = get_output(command)
+reply = run_command_and_read(command)
 vim.command(reply[1:-1])
 EOF
 endfunction

--- a/plugin/ipy.vim
+++ b/plugin/ipy.vim
@@ -1,0 +1,12 @@
+function! IPythonTraceback()
+python << EOF
+command = """
+import sys
+import traceback
+path, line = traceback.extract_tb(sys.last_traceback)[-1][0:2]
+'edit +%d %s' % (line, path)
+"""
+reply = get_output(command)
+vim.command(reply[1:-1])
+EOF
+endfunction


### PR DESCRIPTION
Upon executing :IPython in Vim, a lot of warnings are displayed, such as "ShimWarning: The `IPython.config` package has been deprecated." The file ftplugin/python/vim_ipython.py is using some deprecated functions and this path tries to resolve them while staying backwards compatible.

[warnings.txt](https://github.com/ivanov/vim-ipython/files/158932/warnings.txt)
